### PR TITLE
fix: shuffle instance image path collation.

### DIFF
--- a/src/datasets.py
+++ b/src/datasets.py
@@ -1,5 +1,4 @@
 import itertools
-import random
 from typing import Callable, Dict, List, Tuple
 
 import keras_cv
@@ -120,7 +119,6 @@ class DatasetUtils:
         new_instance_image_paths = []
         num_class_image_paths = len(class_image_paths)
         indices = list(range(num_class_image_paths))
-        random.shuffle(indices)
 
         for index in indices:
             instance_image = instance_image_paths[index % len(instance_image_paths)]
@@ -193,8 +191,8 @@ class DatasetUtils:
         """Assembles `tf.data.Dataset` object from image paths and their corresponding
         captions. `texts` can either be tokens or embedded tokens."""
         dataset = tf.data.Dataset.from_tensor_slices((image_paths, texts))
-        dataset = dataset.map(self._process_image, num_parallel_calls=AUTO)
         dataset = dataset.shuffle(5, reshuffle_each_iteration=True)
+        dataset = dataset.map(self._process_image, num_parallel_calls=AUTO)
         dataset = dataset.batch(self.batch_size)
         dataset = dataset.map(self._apply_augmentation, num_parallel_calls=AUTO)
 


### PR DESCRIPTION
@deep-diver 

As per the [dataloader](https://github.com/huggingface/diffusers/blob/main/examples/dreambooth/train_dreambooth.py#L385) of the DreamBooth training example from `diffusers`, the instance image indices are randomly sampled w.r.t the current dataloader index. Same for the class image indices. 

In my understanding, it is equivalent to what we are doing with the [collation function](https://github.com/sayakpaul/dreambooth-keras/blob/main/src/datasets.py#L115) in the dataset utils class except the indices should be shuffled since the dataset indices is shuffled in the `diffusers` DreamBooth example [here](https://github.com/huggingface/diffusers/blob/main/examples/dreambooth/train_dreambooth.py#L652). 

This is why, it's important to ensure the shuffling in our data utils class is introduced in the right position. This PR attempts to fix it. 

Here is a Colab demo to understand it a bit more: https://colab.research.google.com/gist/sayakpaul/61adeeeb1696d0d5bb081f106a1916a0/scratchpad.ipynb.

So for sanity, I will rerun my experiments from #11. 

This is an important part. Let me know if you have any questions. 